### PR TITLE
fix: prevent Shiki plugin from breaking HTML structure of other plugins

### DIFF
--- a/src/main/java/run/halo/shiki/ShikiPreTagProcessor.java
+++ b/src/main/java/run/halo/shiki/ShikiPreTagProcessor.java
@@ -27,7 +27,8 @@ public class ShikiPreTagProcessor {
             }
         }
 
+        doc.outputSettings(new Document.OutputSettings().prettyPrint(false));
+
         return doc.body().html();
     }
 }
-


### PR DESCRIPTION
fix #11 

添加了Jsoup 输出配置来关闭对HTML的格式化

```java
doc.outputSettings(new Document.OutputSettings().prettyPrint(false));
```

```release-note
修复与 Vditor 编辑器、文本绘图等插件的兼容性问题。
```