### PR TITLE
fix: add caching for code block syntax highlighting

### DIFF
--- a/ui/src/editor/code-block-shiki/shiki-plugin.ts
+++ b/ui/src/editor/code-block-shiki/shiki-plugin.ts
@@ -298,11 +298,3 @@ export function ShikiPlugin({
 
   return shikiPlugin;
 }
-
-/**
- * 清理装饰器缓存
- * 可在需要时手动调用，比如切换主题或语言包后
- */
-export function clearDecorationsCache() {
-  tokensCache.clear();
-}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

目前代码块在输入任何文本时，会调用当前所有代码块进行 `codeToTokensBase`，即便不是当前正在修改的代码块。这会造成严重的性能损耗。
此 PR 对每个代码块的 `tokens` 进行了缓存，根据 `语言-主题-内容` 做 Hash 处理，大大降低了性能损耗。

20 个代码块的性能：
Before:

124 ms

after:

4ms

#### Does this PR introduce a user-facing change?
```release-note
解决当页面具有大量代码块时编辑代码块会导致卡顿的问题。
```
