### PR TITLE
Add Mermaid rendering support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@halo-dev/shiki-code-element':
         specifier: workspace:*
         version: link:../shiki-code-element
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
     devDependencies:
       terser:
         specifier: ^5.46.0
@@ -215,6 +218,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -317,6 +326,9 @@ packages:
 
   '@lit/reactive-element@2.1.1':
     resolution: {integrity: sha512-N+dm5PAYdQ8e6UlywyyrgI2t++wFGXfHx+dSJ1oBrg6FAxUj40jId++EaRm80MKX5JnlH1sBsyZ5h0bcZKemCg==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@microsoft/api-extractor-model@7.31.1':
     resolution: {integrity: sha512-Dhnip5OFKbl85rq/ICHBFGhV4RA5UQSl8AC/P/zoGvs+CBudPkatt5kIhMGiYgVPnUWmfR6fcp38+1AFLYNtUw==}
@@ -999,8 +1011,104 @@ packages:
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -1104,6 +1212,9 @@ packages:
     resolution: {integrity: sha512-HLmzDvde3BJ2C6iromHVE21lmNm4SmGSMlbSbFuLPOmWV11XhhHBkAOzytSxPBRG0dbuo+InSGUM14Ek2d6UDg==}
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-vue@6.0.1':
     resolution: {integrity: sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==}
@@ -1317,6 +1428,14 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -1336,6 +1455,12 @@ packages:
   core-js@3.47.0:
     resolution: {integrity: sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
@@ -1345,6 +1470,165 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -1360,6 +1644,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1378,6 +1665,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1412,6 +1702,9 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1511,6 +1804,9 @@ packages:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1541,12 +1837,23 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1600,8 +1907,21 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lib0@0.2.116:
     resolution: {integrity: sha512-4zsosjzmt33rx5XjmFVYUAeLNh+BTeDTiwGdLt4muxiir2btsc60Nal0EvkvDRizg+pnlK1q+BtYi7M+d4eStw==}
@@ -1710,6 +2030,9 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -1728,6 +2051,11 @@ packages:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1740,6 +2068,9 @@ packages:
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -1844,6 +2175,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -1874,6 +2208,12 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2002,6 +2342,9 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2014,6 +2357,9 @@ packages:
 
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   rspack-vue-loader@17.5.0:
     resolution: {integrity: sha512-hJrL2+jytfTs6ORHBOKTh5lU7BVZvmv7afELuQfyEpGC1ll7MKj1BxlgAIbhd6pZwoEwfdH79Lewtwe4VOlfCQ==}
@@ -2028,6 +2374,12 @@ packages:
         optional: true
       vue:
         optional: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sass@1.78.0:
     resolution: {integrity: sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==}
@@ -2118,6 +2470,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2152,6 +2507,10 @@ packages:
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2221,6 +2580,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2431,6 +2794,10 @@ snapshots:
   '@biomejs/cli-win32-x64@2.2.4':
     optional: true
 
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -2604,6 +2971,10 @@ snapshots:
   '@lit/reactive-element@2.1.1':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.4.0
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@microsoft/api-extractor-model@7.31.1(@types/node@20.19.35)':
     dependencies:
@@ -3230,7 +3601,126 @@ snapshots:
 
   '@types/argparse@1.0.38': {}
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -3393,6 +3883,11 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin-utils: 0.3.1
       vite: 8.0.16(@types/node@20.19.35)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.0)(yaml@2.8.1)
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-vue@6.0.1(vite@8.0.16(@types/node@20.19.35)(jiti@2.6.1)(sass@1.78.0)(terser@5.46.0)(yaml@2.8.1))(vue@3.5.29(typescript@5.9.3))':
     dependencies:
@@ -3647,6 +4142,10 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   compare-versions@6.1.1: {}
 
   compute-scroll-into-view@3.1.0: {}
@@ -3659,6 +4158,14 @@ snapshots:
 
   core-js@3.47.0: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   crelt@1.0.6: {}
 
   css-tree@3.1.0:
@@ -3668,6 +4175,192 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.21: {}
+
   de-indent@1.0.2: {}
 
   debug@4.4.3:
@@ -3675,6 +4368,10 @@ snapshots:
       ms: 2.1.3
 
   defu@6.1.4: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -3687,6 +4384,10 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3711,6 +4412,8 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.47.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3792,6 +4495,8 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -3824,10 +4529,18 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   immutable@4.3.7:
     optional: true
 
   import-lazy@4.0.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -3874,7 +4587,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kolorist@1.8.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lib0@0.2.116:
     dependencies:
@@ -3976,6 +4699,8 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  lodash-es@4.18.1: {}
+
   lodash@4.17.21: {}
 
   log-update@6.1.0:
@@ -4003,6 +4728,8 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  marked@16.4.2: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.0:
@@ -4020,6 +4747,30 @@ snapshots:
   mdn-data@2.12.2: {}
 
   mdurl@2.0.0: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.0
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.8
+      es-toolkit: 1.47.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -4117,6 +4868,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-parse@1.0.7: {}
 
   pathe@2.0.3: {}
@@ -4142,6 +4895,13 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.15:
     dependencies:
@@ -4306,6 +5066,8 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -4358,6 +5120,13 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   rspack-vue-loader@17.5.0(@rspack/core@1.7.6(@swc/helpers@0.5.19))(vue@3.5.29(typescript@5.9.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
@@ -4365,6 +5134,10 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.7.6(@swc/helpers@0.5.19)
       vue: 3.5.29(typescript@5.9.3)
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
 
   sass@1.78.0:
     dependencies:
@@ -4481,6 +5254,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4512,6 +5287,8 @@ snapshots:
   totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
+
+  ts-dedent@2.2.0: {}
 
   tslib@2.8.1: {}
 
@@ -4594,6 +5371,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@14.0.0: {}
 
   vfile-message@4.0.3:
     dependencies:

--- a/shiki-code-element/src/variants/mac.ts
+++ b/shiki-code-element/src/variants/mac.ts
@@ -27,34 +27,26 @@ export class ShikiCodeMacVariant extends ShikiCodeBaseVariant {
           </div>
           <div class="inline-flex items-center gap-2">
             <button
-              class="select-none"
-              tabindex="-1"
+              class="mac-action-button"
+              style="color: ${this.options.theme?.fg}; border-color: ${this.options.theme?.fg};"
+              tabindex="0"
+              title=${this.fold ? "展开代码" : "折叠代码"}
+              aria-label=${this.fold ? "展开代码" : "折叠代码"}
               @click=${() => {
                 this.fold = !this.fold;
               }}
             >
-              ${when(
-                this.fold,
-                () =>
-                  html`<i
-                    class="i-mingcute-left-line block"
-                    style="color: ${this.options.theme?.fg}"
-                  ></i>`,
-                () =>
-                  html`<i
-                    class="i-mingcute-down-line block"
-                    style="color: ${this.options.theme?.fg}"
-                  ></i>`,
-              )}
+              ${this.fold ? "展开" : "折叠"}
             </button>
-            <button class="select-none" tabindex="-1" @click=${this.handleCopyCode}>
-              ${when(
-                this.copied,
-                () =>
-                  html`<i class="i-tabler-check block" style="color: ${this.options.theme?.fg}"></i>`,
-                () =>
-                  html`<i class="i-tabler-copy block" style="color: ${this.options.theme?.fg}"></i>`,
-              )}
+            <button
+              class="mac-action-button"
+              style="color: ${this.options.theme?.fg}; border-color: ${this.options.theme?.fg};"
+              tabindex="0"
+              title="复制代码"
+              aria-label="复制代码"
+              @click=${this.handleCopyCode}
+            >
+              ${this.copied ? "已复制" : "复制"}
             </button>
           </div>
         </header>
@@ -71,6 +63,29 @@ export class ShikiCodeMacVariant extends ShikiCodeBaseVariant {
     unsafeCSS(reset),
     unsafeCSS(shikiStyle),
     css`
+      .mac-action-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2.5rem;
+        height: 1.75rem;
+        padding: 0 0.625rem;
+        border-width: 1px;
+        border-style: solid;
+        border-radius: 0.375rem;
+        background: transparent;
+        font-size: 0.75rem;
+        line-height: 1;
+        opacity: 0.88;
+        cursor: pointer;
+        user-select: none;
+      }
+      .mac-action-button:hover,
+      .mac-action-button:focus-visible {
+        opacity: 1;
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+      }
       @unocss-placeholder;
     `,
   ];

--- a/shiki-code-element/src/variants/simple.ts
+++ b/shiki-code-element/src/variants/simple.ts
@@ -1,7 +1,6 @@
 import reset from "@unocss/reset/tailwind.css?inline";
 import { css, html, unsafeCSS } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { when } from "lit/directives/when.js";
 import shikiStyle from "../styles/shiki.css?inline";
 import { ShikiCodeBaseVariant } from "./base";
 
@@ -11,24 +10,20 @@ export class ShikiCodeSimpleVariant extends ShikiCodeBaseVariant {
       <div class="shadow rounded-lg relative group">
         ${unsafeHTML(this.options.html)}
         <div
-          class="absolute select-none top-1 text-xs right-2 group-hover:opacity-0 transition-opacity"
+          class="absolute select-none top-1 text-xs right-14 transition-opacity"
           style="color: ${this.options.theme?.fg}"
         >
           ${this.options.languageName}
         </div>
         <button
-          class="opacity-0 z-2 select-none group-hover:opacity-100 transition-opacity absolute top-2 rounded right-2 size-8 inline-flex items-center justify-center"
-          style="background-color: ${this.options.theme?.bg};"
+          class="copy-button"
+          style="background-color: ${this.options.theme?.bg}; color: ${this.options.theme?.fg}; border-color: ${this.options.theme?.fg};"
           @click=${this.handleCopyCode}
-          tabindex="-1"
+          title="复制代码"
+          aria-label="复制代码"
+          tabindex="0"
         >
-          ${when(
-            this.copied,
-            () =>
-              html`<i class="i-tabler-check block" style="color: ${this.options.theme?.fg}"></i>`,
-            () =>
-              html`<i class="i-tabler-copy block" style="color: ${this.options.theme?.fg}"></i>`,
-          )}
+          ${this.copied ? "已复制" : "复制"}
         </button>
       </div>
     `;
@@ -40,6 +35,32 @@ export class ShikiCodeSimpleVariant extends ShikiCodeBaseVariant {
     css`
       .shiki {
         border-radius: inherit;
+      }
+      .copy-button {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        z-index: 10;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2.5rem;
+        height: 1.75rem;
+        padding: 0 0.625rem;
+        border-width: 1px;
+        border-style: solid;
+        border-radius: 0.375rem;
+        font-size: 0.75rem;
+        line-height: 1;
+        opacity: 0.88;
+        cursor: pointer;
+        user-select: none;
+      }
+      .copy-button:hover,
+      .copy-button:focus-visible {
+        opacity: 1;
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
       }
       @unocss-placeholder;
     `,

--- a/src/main/java/run/halo/shiki/MermaidHeadProcessor.java
+++ b/src/main/java/run/halo/shiki/MermaidHeadProcessor.java
@@ -1,0 +1,80 @@
+package run.halo.shiki;
+
+import java.util.Properties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.thymeleaf.context.Contexts;
+import org.thymeleaf.context.ITemplateContext;
+import org.thymeleaf.model.IModel;
+import org.thymeleaf.processor.element.IElementModelStructureHandler;
+import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginContext;
+import run.halo.app.theme.dialect.TemplateHeadProcessor;
+
+@Component
+@RequiredArgsConstructor
+public class MermaidHeadProcessor implements TemplateHeadProcessor {
+    static final PropertyPlaceholderHelper PROPERTY_PLACEHOLDER_HELPER =
+        new PropertyPlaceholderHelper("${", "}");
+
+    private final PluginContext pluginContext;
+
+    private final ShikiBasicConfigSupplier shikiBasicConfigSupplier;
+
+    @Override
+    public Mono<Void> process(ITemplateContext context, IModel model,
+        IElementModelStructureHandler structureHandler) {
+        if (!Contexts.isWebContext(context)) {
+            return Mono.empty();
+        }
+
+        return shikiBasicConfigSupplier.get()
+            .filter(ShikiBasicConfig::isMermaidEnabled)
+            .doOnNext(basicConfig -> model.add(
+                context.getModelFactory().createText(mermaidScript(basicConfig))
+            ))
+            .then();
+    }
+
+    private String mermaidScript(ShikiBasicConfig basicConfig) {
+        final Properties properties = new Properties();
+        properties.setProperty("version", pluginContext.getVersion());
+        properties.setProperty("lightTheme", escapeJavaScript(basicConfig.getMermaidLightTheme()));
+        properties.setProperty("darkTheme", escapeJavaScript(basicConfig.getMermaidDarkTheme()));
+        properties.setProperty("securityLevel", escapeJavaScript(basicConfig.getMermaidSecurityLevel()));
+        properties.setProperty("defaultViewMode",
+            escapeJavaScript(basicConfig.getMermaidDefaultViewMode()));
+        properties.setProperty("zoomEnabled", Boolean.toString(basicConfig.isMermaidZoomEnabled()));
+        properties.setProperty("fullscreenEnabled",
+            Boolean.toString(basicConfig.isMermaidFullscreenEnabled()));
+
+        return PROPERTY_PLACEHOLDER_HELPER.replacePlaceholders("""
+            <!-- plugin-shiki mermaid start -->
+            <script class="pjax" data-pjax>
+            window.__HALO_SHIKI_MERMAID_CONFIG__ = {
+                lightTheme: '${lightTheme}',
+                darkTheme: '${darkTheme}',
+                securityLevel: '${securityLevel}',
+                defaultViewMode: '${defaultViewMode}',
+                zoomEnabled: ${zoomEnabled},
+                fullscreenEnabled: ${fullscreenEnabled}
+            };
+            </script>
+            <script type="module" class="pjax" data-pjax src="/plugins/shiki/assets/static/mermaid-renderer.js?version=${version}"></script>
+            <!-- plugin-shiki mermaid end -->
+            """, properties);
+    }
+
+    private static String escapeJavaScript(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+            .replace("\r", "\\r")
+            .replace("\n", "\\n")
+            .replace("</", "<\\/");
+    }
+}

--- a/src/main/java/run/halo/shiki/MermaidPostContentHandler.java
+++ b/src/main/java/run/halo/shiki/MermaidPostContentHandler.java
@@ -1,0 +1,30 @@
+package run.halo.shiki;
+
+import com.google.common.base.Throwables;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.ReactivePostContentHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MermaidPostContentHandler implements ReactivePostContentHandler {
+
+    private final ShikiBasicConfigSupplier shikiBasicConfigSupplier;
+
+    @Override
+    public Mono<PostContentContext> handle(PostContentContext contentContext) {
+        return shikiBasicConfigSupplier.get().map(basicConfig -> {
+            if (!basicConfig.isMermaidEnabled()) {
+                return contentContext;
+            }
+            contentContext.setContent(MermaidPreTagProcessor.process(contentContext.getContent()));
+            return contentContext;
+        }).onErrorResume(e -> {
+            log.error("Failed to process mermaid diagram", Throwables.getRootCause(e));
+            return Mono.just(contentContext);
+        });
+    }
+}

--- a/src/main/java/run/halo/shiki/MermaidPreTagProcessor.java
+++ b/src/main/java/run/halo/shiki/MermaidPreTagProcessor.java
@@ -1,0 +1,56 @@
+package run.halo.shiki;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class MermaidPreTagProcessor {
+    private static final String MERMAID_CONTAINER_CLASS = "halo-mermaid-diagram";
+
+    static String process(String content) {
+        Document doc = Jsoup.parse(content);
+        Elements preElements = doc.select("pre:has(> code)");
+
+        for (Element preElement : preElements) {
+            Element codeElement = preElement.selectFirst("code");
+            if (codeElement == null || !isMermaidCodeBlock(codeElement)) {
+                continue;
+            }
+
+            Element parentElement = preElement.parent();
+            if (parentElement != null && parentElement.hasClass(MERMAID_CONTAINER_CLASS)) {
+                continue;
+            }
+
+            Element mermaidElement = new Element("div")
+                .addClass(MERMAID_CONTAINER_CLASS)
+                .attr("data-mermaid-source", codeElement.text());
+
+            preElement.replaceWith(mermaidElement);
+            mermaidElement.appendChild(preElement);
+        }
+
+        doc.outputSettings(new Document.OutputSettings().prettyPrint(false));
+        return doc.body().html();
+    }
+
+    private static boolean isMermaidCodeBlock(Element codeElement) {
+        String languageCode = extractLanguageCode(codeElement);
+        return "mermaid".equalsIgnoreCase(languageCode);
+    }
+
+    private static String extractLanguageCode(Element codeElement) {
+        String[] supportedPrefixes = {"language-", "lang-"};
+
+        for (String className : codeElement.classNames()) {
+            for (String prefix : supportedPrefixes) {
+                if (className.startsWith(prefix)) {
+                    return className.substring(prefix.length()).toLowerCase();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/run/halo/shiki/MermaidSinglePageContentHandler.java
+++ b/src/main/java/run/halo/shiki/MermaidSinglePageContentHandler.java
@@ -1,0 +1,30 @@
+package run.halo.shiki;
+
+import com.google.common.base.Throwables;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import run.halo.app.theme.ReactiveSinglePageContentHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MermaidSinglePageContentHandler implements ReactiveSinglePageContentHandler {
+
+    private final ShikiBasicConfigSupplier shikiBasicConfigSupplier;
+
+    @Override
+    public Mono<SinglePageContentContext> handle(SinglePageContentContext contentContext) {
+        return shikiBasicConfigSupplier.get().map(basicConfig -> {
+            if (!basicConfig.isMermaidEnabled()) {
+                return contentContext;
+            }
+            contentContext.setContent(MermaidPreTagProcessor.process(contentContext.getContent()));
+            return contentContext;
+        }).onErrorResume(e -> {
+            log.error("Failed to process mermaid diagram", Throwables.getRootCause(e));
+            return Mono.just(contentContext);
+        });
+    }
+}

--- a/src/main/java/run/halo/shiki/ShikiBasicConfig.java
+++ b/src/main/java/run/halo/shiki/ShikiBasicConfig.java
@@ -1,7 +1,7 @@
 package run.halo.shiki;
 
-import lombok.Data;
 import java.util.List;
+import lombok.Data;
 
 /**
  * @author ryanwang
@@ -20,11 +20,42 @@ public class ShikiBasicConfig {
 
     private String fontSize;
 
+    private boolean mermaidEnabled = true;
+
+    private String mermaidLightTheme = "default";
+
+    private String mermaidDarkTheme = "dark";
+
+    private boolean mermaidZoomEnabled = true;
+
+    private boolean mermaidFullscreenEnabled = true;
+
+    private String mermaidSecurityLevel = "strict";
+
+    private String mermaidDefaultViewMode = "preview";
+
     /**
      * List of language codes to exclude from Shiki highlighting.
      * Code blocks with these languages will maintain their original pre>code structure
      * and can be processed by other plugins or JavaScript libraries.
      * Examples: mermaid, plantuml, d2, graphviz
      */
-    private List<String> excludedLanguages;
+    private List<String> excludedLanguages = List.of("mermaid");
+
+    public List<String> getEffectiveExcludedLanguages() {
+        if (!mermaidEnabled) {
+            return excludedLanguages;
+        }
+        if (excludedLanguages == null || excludedLanguages.isEmpty()) {
+            return List.of("mermaid");
+        }
+        boolean hasMermaid = excludedLanguages.stream()
+            .anyMatch(excluded -> "mermaid".equalsIgnoreCase(excluded));
+        if (hasMermaid) {
+            return excludedLanguages;
+        }
+        var effectiveExcludedLanguages = new java.util.ArrayList<>(excludedLanguages);
+        effectiveExcludedLanguages.add("mermaid");
+        return effectiveExcludedLanguages;
+    }
 }

--- a/src/main/java/run/halo/shiki/ShikiHeadProcessor.java
+++ b/src/main/java/run/halo/shiki/ShikiHeadProcessor.java
@@ -1,6 +1,5 @@
 package run.halo.shiki;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import lombok.RequiredArgsConstructor;
@@ -91,13 +90,14 @@ public class ShikiHeadProcessor implements TemplateHeadProcessor {
         properties.setProperty("variant", basicConfig.getVariant());
         properties.setProperty("fontSize", basicConfig.getFontSize());
         properties.setProperty("version", pluginContext.getVersion());
-        properties.setProperty("style", Constants.generatePreStyle(basicConfig.getExcludedLanguages()));
+        properties.setProperty("style", Constants.generatePreStyle(basicConfig.getEffectiveExcludedLanguages()));
         
         // Convert excludedLanguages list to JSON array string
         String excludedLanguagesJson = "[]";
-        if (basicConfig.getExcludedLanguages() != null && !basicConfig.getExcludedLanguages().isEmpty()) {
+        var effectiveExcludedLanguages = basicConfig.getEffectiveExcludedLanguages();
+        if (effectiveExcludedLanguages != null && !effectiveExcludedLanguages.isEmpty()) {
             excludedLanguagesJson = "[" + String.join(",", 
-                basicConfig.getExcludedLanguages().stream()
+                effectiveExcludedLanguages.stream()
                     .map(lang -> "'" + lang + "'")
                     .toList()
             ) + "]";

--- a/src/main/java/run/halo/shiki/ShikiPreTagProcessor.java
+++ b/src/main/java/run/halo/shiki/ShikiPreTagProcessor.java
@@ -1,10 +1,10 @@
 package run.halo.shiki;
 
+import java.util.List;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import java.util.List;
 
 public class ShikiPreTagProcessor {
     static String process(String content, ShikiBasicConfig basicConfig) {
@@ -16,7 +16,7 @@ public class ShikiPreTagProcessor {
         // Process each pre element
         for (Element preElement : preElements) {
             Element codeElement = preElement.selectFirst("code");
-            if (codeElement != null && shouldExclude(codeElement, basicConfig.getExcludedLanguages())) {
+            if (codeElement != null && shouldExclude(codeElement, basicConfig.getEffectiveExcludedLanguages())) {
                 // Skip processing for excluded languages
                 continue;
             }

--- a/src/main/resources/extensions/extension-definitions.yaml
+++ b/src/main/resources/extensions/extension-definitions.yaml
@@ -17,3 +17,23 @@ spec:
   extensionPointName: reactive-singlepage-content-handler
   displayName: "Shiki 代码高亮处理器"
   description: "使用 Shiki 进行代码高亮的页面内容处理器"
+---
+apiVersion: plugin.halo.run/v1alpha1
+kind: ExtensionDefinition
+metadata:
+  name: post-content-mermaid-handler
+spec:
+  className: run.halo.shiki.MermaidPostContentHandler
+  extensionPointName: reactive-post-content-handler
+  displayName: "Mermaid 图表处理器"
+  description: "将文章内容中的 Mermaid 代码块转换为可渲染图表容器"
+---
+apiVersion: plugin.halo.run/v1alpha1
+kind: ExtensionDefinition
+metadata:
+  name: singlepage-content-mermaid-handler
+spec:
+  className: run.halo.shiki.MermaidSinglePageContentHandler
+  extensionPointName: reactive-singlepage-content-handler
+  displayName: "Mermaid 图表处理器"
+  description: "将页面内容中的 Mermaid 代码块转换为可渲染图表容器"

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -45,6 +45,8 @@ spec:
           autoSelect: false
           multiple: true
           help: 排除指定语言的代码块不进行 Shiki 高亮渲染，适用于需要其他插件处理的特定语言（如 mermaid、plantuml 等）。排除的代码块将保留原始的 pre>code 结构，不被 shiki-code 元素包裹。
+          value:
+            - mermaid
           options:
             - label: Mermaid
               value: mermaid
@@ -366,6 +368,91 @@ spec:
             lightTheme: $get(lightTheme).value
             darkTheme: $get(darkTheme).value
             fontSize: $get(fontSize).value
+        - $formkit: checkbox
+          name: mermaidEnabled
+          id: mermaidEnabled
+          key: mermaidEnabled
+          label: 启用 Mermaid 图表渲染
+          help: 启用后会自动渲染文章和页面中的 Mermaid 代码块，并支持主题切换与缩放操作。
+          value: true
+        - $formkit: select
+          if: $get(mermaidEnabled).value
+          name: mermaidLightTheme
+          id: mermaidLightTheme
+          key: mermaidLightTheme
+          label: Mermaid 亮色主题
+          value: default
+          options:
+            - label: Default
+              value: default
+            - label: Neutral
+              value: neutral
+            - label: Forest
+              value: forest
+            - label: Base
+              value: base
+        - $formkit: select
+          if: $get(mermaidEnabled).value
+          name: mermaidDarkTheme
+          id: mermaidDarkTheme
+          key: mermaidDarkTheme
+          label: Mermaid 暗色主题
+          value: dark
+          options:
+            - label: Dark
+              value: dark
+            - label: Default
+              value: default
+            - label: Neutral
+              value: neutral
+            - label: Forest
+              value: forest
+            - label: Base
+              value: base
+        - $formkit: checkbox
+          if: $get(mermaidEnabled).value
+          name: mermaidZoomEnabled
+          id: mermaidZoomEnabled
+          key: mermaidZoomEnabled
+          label: 启用 Mermaid 缩放
+          value: true
+        - $formkit: checkbox
+          if: $get(mermaidEnabled).value && $get(mermaidZoomEnabled).value
+          name: mermaidFullscreenEnabled
+          id: mermaidFullscreenEnabled
+          key: mermaidFullscreenEnabled
+          label: 启用 Mermaid 全屏查看
+          value: true
+        - $formkit: select
+          if: $get(mermaidEnabled).value
+          name: mermaidDefaultViewMode
+          id: mermaidDefaultViewMode
+          key: mermaidDefaultViewMode
+          label: Mermaid 默认预览模式
+          value: preview
+          help: 选择 Mermaid 代码块首次展示为渲染图表还是源码文本，前台仍可手动切换。
+          options:
+            - label: 渲染预览
+              value: preview
+            - label: 文本预览
+              value: text
+        - $formkit: select
+          if: $get(mermaidEnabled).value
+          name: mermaidSecurityLevel
+          id: mermaidSecurityLevel
+          key: mermaidSecurityLevel
+          label: Mermaid 安全级别
+          value: strict
+          help: strict 安全性最高；如图表需要可点击链接，可选择 loose。
+          options:
+            - label: Strict
+              value: strict
+            - label: Loose
+              value: loose
+            - label: Antiscript
+              value: antiscript
+            - label: Sandbox
+              value: sandbox
     - group: editor
       label: 编辑器设置
       formSchema:

--- a/theme-lib/package.json
+++ b/theme-lib/package.json
@@ -5,7 +5,8 @@
     "build": "tsc && vite build"
   },
   "dependencies": {
-    "@halo-dev/shiki-code-element": "workspace:*"
+    "@halo-dev/shiki-code-element": "workspace:*",
+    "mermaid": "^11.15.0"
   },
   "devDependencies": {
     "terser": "^5.46.0"

--- a/theme-lib/src/mermaid-renderer.ts
+++ b/theme-lib/src/mermaid-renderer.ts
@@ -1,0 +1,586 @@
+import mermaid from "mermaid";
+
+type MermaidViewMode = "preview" | "text";
+
+type MermaidRuntimeConfig = {
+  lightTheme?: string;
+  darkTheme?: string;
+  securityLevel?: string;
+  zoomEnabled?: boolean;
+  fullscreenEnabled?: boolean;
+  defaultViewMode?: MermaidViewMode;
+};
+
+type DiagramState = {
+  scale: number;
+  translateX: number;
+  translateY: number;
+  dragging: boolean;
+  startX: number;
+  startY: number;
+  initialX: number;
+  initialY: number;
+};
+
+declare global {
+  interface Window {
+    __HALO_SHIKI_MERMAID_CONFIG__?: MermaidRuntimeConfig;
+  }
+}
+
+const diagramSelector = ".halo-mermaid-diagram";
+const renderedClass = "halo-mermaid-rendered";
+const styleId = "halo-mermaid-renderer-style";
+let renderCounter = 0;
+let currentTheme = "";
+let renderQueue = Promise.resolve();
+const media = window.matchMedia("(prefers-color-scheme: dark)");
+
+function getConfig(): Required<MermaidRuntimeConfig> {
+  const config = window.__HALO_SHIKI_MERMAID_CONFIG__ || {};
+  return {
+    lightTheme: config.lightTheme || "default",
+    darkTheme: config.darkTheme || "dark",
+    securityLevel: config.securityLevel || "strict",
+    zoomEnabled: config.zoomEnabled ?? true,
+    fullscreenEnabled: config.fullscreenEnabled ?? true,
+    defaultViewMode: config.defaultViewMode || "preview",
+  };
+}
+
+function isDarkMode() {
+  const html = document.documentElement;
+  const body = document.body;
+  const hasClass = (element: HTMLElement, className: string) =>
+    element.classList.contains(className);
+  const hasDataAttr = (element: HTMLElement, value: string) =>
+    element.getAttribute("data-color-scheme") === value;
+
+  if (
+    hasClass(html, "color-scheme-auto") ||
+    hasClass(body, "color-scheme-auto") ||
+    hasDataAttr(html, "auto") ||
+    hasDataAttr(body, "auto")
+  ) {
+    return media.matches;
+  }
+
+  return (
+    hasClass(html, "dark") ||
+    hasClass(body, "dark") ||
+    hasClass(html, "color-scheme-dark") ||
+    hasClass(body, "color-scheme-dark") ||
+    hasDataAttr(html, "dark") ||
+    hasDataAttr(body, "dark") ||
+    media.matches
+  );
+}
+
+function getTheme() {
+  const config = getConfig();
+  return isDarkMode() ? config.darkTheme : config.lightTheme;
+}
+
+function initializeMermaid() {
+  const config = getConfig();
+  const theme = getTheme();
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: theme as
+      | "base"
+      | "default"
+      | "dark"
+      | "forest"
+      | "neutral"
+      | "neo"
+      | "neo-dark"
+      | "redux"
+      | "redux-dark"
+      | "redux-color"
+      | "redux-dark-color"
+      | "null",
+    securityLevel: config.securityLevel as
+      | "strict"
+      | "loose"
+      | "antiscript"
+      | "sandbox",
+  });
+  currentTheme = theme;
+}
+
+function ensureStyle() {
+  if (document.getElementById(styleId)) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = styleId;
+  style.textContent = `
+.halo-mermaid-diagram {
+  position: relative;
+  margin: 1rem 0;
+  border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, Canvas 96%, currentColor 4%);
+  overflow: hidden;
+}
+.halo-mermaid-diagram > pre:not(.halo-mermaid-source) {
+  display: none !important;
+}
+.halo-mermaid-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 10%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, Canvas 96%, currentColor 4%), color-mix(in srgb, Canvas 90%, currentColor 10%));
+}
+.halo-mermaid-button-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.1875rem;
+  border: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, Canvas 88%, currentColor 12%);
+}
+.halo-mermaid-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+.halo-mermaid-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  height: 1.875rem;
+  padding: 0 0.75rem;
+  border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: CanvasText;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  line-height: 1;
+  transition: background-color 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+.halo-mermaid-button:hover,
+.halo-mermaid-button:focus-visible {
+  background: color-mix(in srgb, CanvasText 8%, Canvas);
+  transform: translateY(-1px);
+  outline: none;
+}
+.halo-mermaid-button.is-active {
+  border-color: color-mix(in srgb, currentColor 36%, transparent);
+  background: Canvas;
+  box-shadow: 0 1px 3px color-mix(in srgb, CanvasText 16%, transparent);
+  font-weight: 600;
+}
+.halo-mermaid-viewport {
+  overflow: auto;
+  cursor: grab;
+  overscroll-behavior: contain;
+}
+.halo-mermaid-viewport.is-dragging {
+  cursor: grabbing;
+  user-select: none;
+}
+.halo-mermaid-canvas {
+  display: flex;
+  justify-content: center;
+  min-width: 100%;
+  padding: 1rem;
+  transform-origin: center center;
+  transition: transform 120ms ease;
+}
+.halo-mermaid-canvas svg {
+  max-width: 100%;
+  height: auto;
+}
+.halo-mermaid-source {
+  margin: 0;
+  padding: 1rem;
+  overflow: auto;
+  background: color-mix(in srgb, CanvasText 5%, Canvas);
+  color: CanvasText;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  white-space: pre;
+}
+.halo-mermaid-error {
+  margin: 0;
+  padding: 1rem;
+  overflow: auto;
+  color: #b91c1c;
+  white-space: pre-wrap;
+}
+.halo-mermaid-fullscreen-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.72);
+}
+.halo-mermaid-fullscreen-dialog {
+  width: min(96vw, 1400px);
+  height: min(92vh, 1000px);
+  background: Canvas;
+  color: CanvasText;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}
+.halo-mermaid-fullscreen-dialog .halo-mermaid-viewport,
+.halo-mermaid-fullscreen-dialog .halo-mermaid-source {
+  height: calc(100% - 3rem);
+}
+`;
+  document.head.appendChild(style);
+}
+
+function getSource(element: HTMLElement) {
+  const source =
+    element.dataset.mermaidSource ||
+    element.querySelector("code")?.textContent ||
+    "";
+  return source.trim();
+}
+
+function getViewMode(element: HTMLElement): MermaidViewMode {
+  const mode = element.dataset.mermaidViewMode;
+  if (mode === "preview" || mode === "text") {
+    return mode;
+  }
+  return getConfig().defaultViewMode;
+}
+
+function setTransform(canvas: HTMLElement, state: DiagramState) {
+  canvas.style.transform = `translate(${state.translateX}px, ${state.translateY}px) scale(${state.scale})`;
+}
+
+function zoom(canvas: HTMLElement, state: DiagramState, delta: number) {
+  state.scale = Math.min(4, Math.max(0.2, state.scale + delta));
+  setTransform(canvas, state);
+}
+
+function reset(canvas: HTMLElement, state: DiagramState) {
+  state.scale = 1;
+  state.translateX = 0;
+  state.translateY = 0;
+  setTransform(canvas, state);
+}
+
+function fitWidth(
+  viewport: HTMLElement,
+  canvas: HTMLElement,
+  state: DiagramState,
+) {
+  const svg = canvas.querySelector("svg");
+  if (!svg) {
+    return;
+  }
+  const viewportWidth = viewport.clientWidth - 32;
+  const svgWidth = svg.getBoundingClientRect().width / state.scale;
+  if (svgWidth <= 0) {
+    return;
+  }
+  state.scale = Math.min(4, Math.max(0.2, viewportWidth / svgWidth));
+  state.translateX = 0;
+  state.translateY = 0;
+  setTransform(canvas, state);
+}
+
+function createButton(label: string, title: string, onClick: () => void) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "halo-mermaid-button";
+  button.textContent = label;
+  button.title = title;
+  button.setAttribute("aria-label", title);
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function createModeButton(
+  label: string,
+  mode: MermaidViewMode,
+  activeMode: MermaidViewMode,
+  onClick: () => void,
+) {
+  const button = createButton(
+    label,
+    mode === "preview" ? "渲染预览" : "文本预览",
+    onClick,
+  );
+  if (mode === activeMode) {
+    button.classList.add("is-active");
+  }
+  return button;
+}
+
+async function copySource(source: string, button: HTMLButtonElement) {
+  await navigator.clipboard?.writeText(source);
+  const text = button.textContent;
+  button.textContent = "已复制";
+  setTimeout(() => {
+    button.textContent = text;
+  }, 1600);
+}
+
+function bindPan(
+  viewport: HTMLElement,
+  canvas: HTMLElement,
+  state: DiagramState,
+) {
+  viewport.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0) {
+      return;
+    }
+    state.dragging = true;
+    state.startX = event.clientX;
+    state.startY = event.clientY;
+    state.initialX = state.translateX;
+    state.initialY = state.translateY;
+    viewport.classList.add("is-dragging");
+    viewport.setPointerCapture(event.pointerId);
+  });
+
+  viewport.addEventListener("pointermove", (event) => {
+    if (!state.dragging) {
+      return;
+    }
+    state.translateX = state.initialX + event.clientX - state.startX;
+    state.translateY = state.initialY + event.clientY - state.startY;
+    setTransform(canvas, state);
+  });
+
+  const stopDragging = (event: PointerEvent) => {
+    state.dragging = false;
+    viewport.classList.remove("is-dragging");
+    if (viewport.hasPointerCapture(event.pointerId)) {
+      viewport.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  viewport.addEventListener("pointerup", stopDragging);
+  viewport.addEventListener("pointercancel", stopDragging);
+}
+
+function openFullscreen(source: string) {
+  const overlay = document.createElement("div");
+  overlay.className = "halo-mermaid-fullscreen-overlay";
+
+  const dialog = document.createElement("div");
+  dialog.className = "halo-mermaid-fullscreen-dialog";
+  dialog.dataset.mermaidSource = source;
+  dialog.dataset.mermaidViewMode = getConfig().defaultViewMode;
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
+
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) {
+      overlay.remove();
+    }
+  });
+
+  const closeHandler = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      overlay.remove();
+      document.removeEventListener("keydown", closeHandler);
+    }
+  };
+  document.addEventListener("keydown", closeHandler);
+  void renderDiagram(dialog, true);
+}
+
+function createToolbar(
+  element: HTMLElement,
+  source: string,
+  mode: MermaidViewMode,
+  forceFullscreen: boolean,
+) {
+  const toolbar = document.createElement("div");
+  toolbar.className = "halo-mermaid-toolbar";
+
+  const modeGroup = document.createElement("div");
+  modeGroup.className = "halo-mermaid-button-group";
+  modeGroup.append(
+    createModeButton("图表", "preview", mode, () => {
+      element.dataset.mermaidViewMode = "preview";
+      void renderDiagram(element, forceFullscreen);
+    }),
+    createModeButton("源码", "text", mode, () => {
+      element.dataset.mermaidViewMode = "text";
+      void renderDiagram(element, forceFullscreen);
+    }),
+  );
+
+  const actions = document.createElement("div");
+  actions.className = "halo-mermaid-actions";
+  const copyButton = createButton("复制", "复制 Mermaid 文本", () => {
+    void copySource(source, copyButton);
+  });
+  actions.append(copyButton);
+
+  toolbar.append(modeGroup, actions);
+  return toolbar;
+}
+
+function buildTextView(
+  element: HTMLElement,
+  source: string,
+  mode: MermaidViewMode,
+  forceFullscreen: boolean,
+) {
+  const toolbar = createToolbar(element, source, mode, forceFullscreen);
+  const pre = document.createElement("pre");
+  pre.className = "halo-mermaid-source";
+  pre.textContent = source;
+
+  if (forceFullscreen) {
+    toolbar.append(
+      createButton("×", "关闭", () =>
+        element.closest(".halo-mermaid-fullscreen-overlay")?.remove(),
+      ),
+    );
+  }
+
+  element.innerHTML = "";
+  element.append(toolbar, pre);
+  element.classList.add(renderedClass);
+}
+
+function buildPreview(
+  element: HTMLElement,
+  svg: string,
+  source: string,
+  mode: MermaidViewMode,
+  forceFullscreen = false,
+) {
+  const config = getConfig();
+  const state: DiagramState = {
+    scale: 1,
+    translateX: 0,
+    translateY: 0,
+    dragging: false,
+    startX: 0,
+    startY: 0,
+    initialX: 0,
+    initialY: 0,
+  };
+  const toolbar = createToolbar(element, source, mode, forceFullscreen);
+  const viewport = document.createElement("div");
+  viewport.className = "halo-mermaid-viewport";
+  const canvas = document.createElement("div");
+  canvas.className = "halo-mermaid-canvas";
+  canvas.innerHTML = svg;
+  viewport.appendChild(canvas);
+
+  if (config.zoomEnabled || forceFullscreen) {
+    toolbar.append(
+      createButton("+", "放大", () => zoom(canvas, state, 0.2)),
+      createButton("−", "缩小", () => zoom(canvas, state, -0.2)),
+      createButton("1:1", "重置", () => reset(canvas, state)),
+      createButton("↔", "适应宽度", () => fitWidth(viewport, canvas, state)),
+    );
+    bindPan(viewport, canvas, state);
+  }
+
+  if (config.fullscreenEnabled && !forceFullscreen) {
+    toolbar.append(createButton("⛶", "全屏查看", () => openFullscreen(source)));
+  }
+
+  if (forceFullscreen) {
+    toolbar.append(
+      createButton("×", "关闭", () =>
+        element.closest(".halo-mermaid-fullscreen-overlay")?.remove(),
+      ),
+    );
+  }
+
+  element.innerHTML = "";
+  element.append(toolbar, viewport);
+  element.classList.add(renderedClass);
+}
+
+async function renderDiagram(element: HTMLElement, forceFullscreen = false) {
+  const source = getSource(element);
+  if (!source) {
+    return;
+  }
+
+  element.dataset.mermaidSource = source;
+  const mode = getViewMode(element);
+  element.dataset.mermaidViewMode = mode;
+
+  if (mode === "text") {
+    buildTextView(element, source, mode, forceFullscreen);
+    return;
+  }
+
+  const id = `halo-mermaid-${Date.now()}-${renderCounter++}`;
+
+  try {
+    const { svg } = await mermaid.render(id, source);
+    buildPreview(element, svg, source, mode, forceFullscreen);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    element.innerHTML = `<pre class="halo-mermaid-error"></pre>`;
+    const errorElement = element.querySelector(".halo-mermaid-error");
+    if (errorElement) {
+      errorElement.textContent = message;
+    }
+  }
+}
+
+async function renderAll() {
+  ensureStyle();
+  initializeMermaid();
+  const diagrams = Array.from(
+    document.querySelectorAll<HTMLElement>(diagramSelector),
+  );
+  await Promise.all(diagrams.map((element) => renderDiagram(element)));
+}
+
+function enqueueRenderAll() {
+  renderQueue = renderQueue.then(renderAll).catch(() => undefined);
+}
+
+function rerenderOnThemeChange() {
+  const nextTheme = getTheme();
+  if (nextTheme === currentTheme) {
+    return;
+  }
+  document.querySelectorAll<HTMLElement>(diagramSelector).forEach((element) => {
+    element.classList.remove(renderedClass);
+  });
+  enqueueRenderAll();
+}
+
+const observer = new MutationObserver(rerenderOnThemeChange);
+observer.observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ["class", "data-color-scheme"],
+});
+observer.observe(document.body, {
+  attributes: true,
+  attributeFilter: ["class", "data-color-scheme"],
+});
+
+media.addEventListener("change", rerenderOnThemeChange);
+document.addEventListener("DOMContentLoaded", enqueueRenderAll);
+window.addEventListener("pjax:complete", enqueueRenderAll);
+
+if (document.readyState !== "loading") {
+  enqueueRenderAll();
+}
+
+export { renderAll as renderMermaidDiagrams };

--- a/theme-lib/vite.config.ts
+++ b/theme-lib/vite.config.ts
@@ -26,9 +26,10 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: "./src/index.ts",
-      name: "shiki-code",
-      fileName: `shiki-code`,
+      entry: {
+        "shiki-code": "./src/index.ts",
+        "mermaid-renderer": "./src/mermaid-renderer.ts",
+      },
       formats: ["es"],
     },
     emptyOutDir: true,


### PR DESCRIPTION
## Summary / 摘要

- Add theme-side Mermaid diagram rendering for `language-mermaid` / `lang-mermaid` code blocks in posts and single pages.
- 为文章和独立页面中的 `language-mermaid` / `lang-mermaid` 代码块新增主题侧 Mermaid 图表渲染能力。

- Inject a dedicated Mermaid renderer script with configurable light/dark themes, security level, zoom/fullscreen controls, and default view mode.
- 注入独立 Mermaid 渲染脚本，支持配置亮色/暗色主题、安全级别、缩放/全屏控制以及默认预览模式。

- Add diagram/source view switching, source copy, pan/zoom/fit controls, fullscreen preview, and more reliable text-based copy buttons for Shiki code blocks.
- 新增图表/源码视图切换、源码复制、拖拽/缩放/适应宽度、全屏预览，并将 Shiki 代码块复制按钮改为更可靠的文字按钮。

## Details / 变更说明

- Adds `MermaidPostContentHandler` and `MermaidSinglePageContentHandler` to wrap Mermaid code blocks in a stable `.halo-mermaid-diagram` container.
- 新增 `MermaidPostContentHandler` 与 `MermaidSinglePageContentHandler`，将 Mermaid 代码块包装为稳定的 `.halo-mermaid-diagram` 容器。

- Adds `MermaidHeadProcessor` to pass runtime configuration and load `/plugins/shiki/assets/static/mermaid-renderer.js`.
- 新增 `MermaidHeadProcessor`，用于传递运行时配置并加载 `/plugins/shiki/assets/static/mermaid-renderer.js`。

- Ensures Mermaid code blocks are effectively excluded from Shiki highlighting when Mermaid rendering is enabled, even if existing settings do not explicitly include `mermaid` in excluded languages.
- 当 Mermaid 渲染启用时，即使已有配置没有显式把 `mermaid` 加入排除语言，也会确保 Mermaid 代码块不会被 Shiki 高亮接管。

- Updates settings to expose Mermaid rendering options: enable switch, light/dark themes, zoom, fullscreen, security level, and default preview mode.
- 更新后台设置项，暴露 Mermaid 渲染开关、亮/暗主题、缩放、全屏、安全级别和默认预览模式。

- Improves Shiki code block copy controls by avoiding missing Iconify icon rendering and using visible text buttons.
- 优化 Shiki 代码块复制按钮，避免 Iconify 图标缺失导致按钮不可见，改用明确可见的文字按钮。

## Test plan / 测试计划

- `pnpm check`
- `JAVA_HOME=C:\Users\zhang\.jdks\azul-21.0.11 gradlew.bat clean jar --console plain`

Manual checks / 手动验证：

- Render a post/page containing a Mermaid code block and verify it displays as a diagram by default.
- 在文章/页面中插入 Mermaid 代码块，确认默认可渲染为图表。

- Toggle Mermaid between diagram and source views inline and in fullscreen mode.
- 分别在页面内嵌模式和全屏模式下切换 Mermaid 图表/源码视图。

- Verify zoom in, zoom out, reset, fit width, drag/pan, fullscreen, and copy source actions.
- 验证放大、缩小、重置、适应宽度、拖拽平移、全屏和复制源码功能。

- Verify Shiki code block copy buttons are visible in both simple and Mac variants.
- 验证 Shiki 代码块在 simple 和 Mac 两种风格下复制按钮均可见。